### PR TITLE
Add PIC12F1822 DHT22 1‑Wire DS2438 firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
-# 1-Wire-DHT22
-1-Wire DHT22 controller using PIC
+# PIC12F1822 DHT22 to 1-Wire DS2438
+
+This project converts a DHT22 temperature and humidity sensor to a Dallas 1‑Wire slave using a PIC12F1822 microcontroller. It emulates a DS2438 device so existing 1‑Wire software can read both temperature and humidity.
+
+The implementation adapts the timing model from the open source [OneWireHub](https://github.com/orgua/OneWireHub) library.
+
+## Changing the 1‑Wire address
+
+Edit `src/config.h` and modify the `OW_ROM_*` defines. The family code should remain `0x26` for a DS2438 compatible device. Example:
+
+```c
+#define OW_ROM_SERIAL1 0x01
+#define OW_ROM_SERIAL2 0x02
+#define OW_ROM_SERIAL3 0x03
+#define OW_ROM_SERIAL4 0x04
+#define OW_ROM_SERIAL5 0x05
+#define OW_ROM_SERIAL6 0x06
+#define OW_ROM_CRC     0xA1
+```
+
+Recompile after changing these values.
+
+## Building
+
+1. Install MPLAB X and XC8 compiler from Microchip.
+2. Create a new stand‑alone project for the PIC12F1822 and add all files from the `src` directory.
+3. Set the processor frequency to 8 MHz and build the project. No extra libraries are required.
+
+## Flashing
+
+Use a PICkit or compatible programmer:
+
+1. Connect Vdd, Vss, PGD (ICSPDAT), PGC (ICSPCLK) and MCLR to the programmer.
+2. Program the generated `.hex` file using MPLAB X or the stand‑alone IPE tool.
+
+## Testing
+
+1. Connect the DHT22 data pin to RA1 of the PIC and a 10 kΩ pull‑up to Vdd.
+2. Connect RA0 to the 1‑Wire bus with a pull‑up resistor (4.7 kΩ typical).
+3. Power the PIC with 3.3 V or 5 V.
+4. Use a 1‑Wire master (for example DS9490R with `owfs`) to detect the DS2438 device and read temperature and humidity.
+
+## Home Assistant integration
+
+1. Install the [OneWire](https://www.home-assistant.io/integrations/onewire/) integration and ensure the 1‑Wire bus is accessible (via OWFS or SysBus).
+2. After adding the integration, Home Assistant will detect the DS2438 device automatically.
+3. Two sensors will be created:
+   - `temperature` mapped from DS2438 temperature register.
+   - `humidity` mapped from the ADC register which this firmware stores as relative humidity.
+4. Use these sensors in dashboards or automations as any other temperature and humidity readings.
+

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,22 @@
+#ifndef CONFIG_H
+#define CONFIG_H
+
+// 1-Wire device ROM (family code + 6-byte serial + CRC)
+// Default address: family 0x26 (DS2438) with example serial number
+// Change these values to modify the address
+#define OW_ROM_FAMILY 0x26
+#define OW_ROM_SERIAL1 0x01
+#define OW_ROM_SERIAL2 0x23
+#define OW_ROM_SERIAL3 0x45
+#define OW_ROM_SERIAL4 0x67
+#define OW_ROM_SERIAL5 0x89
+#define OW_ROM_SERIAL6 0xAB
+#define OW_ROM_CRC     0xCD
+
+// Pin assignments
+#define OW_PIN   RA0
+#define OW_TRIS  TRISA0
+#define DHT_PIN  RA1
+#define DHT_TRIS TRISA1
+
+#endif // CONFIG_H

--- a/src/dht22.c
+++ b/src/dht22.c
@@ -1,0 +1,44 @@
+#include <xc.h>
+#include "dht22.h"
+#include "config.h"
+
+#define _XTAL_FREQ 8000000UL
+
+static void dht_delay_us(unsigned int us) {
+    while(us--) __delay_us(1);
+}
+
+uint8_t dht22_read(int16_t *temp, uint16_t *hum) {
+    uint8_t bits[5] = {0};
+    uint8_t i, j;
+
+    // send start signal
+    DHT_TRIS = 0; // output
+    DHT_PIN = 0;
+    dht_delay_us(1200); // >1ms
+    DHT_TRIS = 1; // input
+    dht_delay_us(30);
+
+    // wait for sensor response
+    if (DHT_PIN) return 1;
+    while(!DHT_PIN); // low 80us
+    while(DHT_PIN);  // high 80us
+
+    // read 40 bits
+    for (j = 0; j < 5; j++) {
+        for(i = 0; i < 8; i++) {
+            while(!DHT_PIN); // start of bit (50us low)
+            dht_delay_us(30);
+            bits[j] <<= 1;
+            if (DHT_PIN) bits[j] |= 1; // if high after 30us -> 1
+            while(DHT_PIN); // wait end
+        }
+    }
+
+    uint8_t chk = bits[0] + bits[1] + bits[2] + bits[3];
+    if (chk != bits[4]) return 2;
+
+    *hum  = ((uint16_t)bits[0] << 8) | bits[1];
+    *temp = ((int16_t)bits[2] << 8) | bits[3];
+    return 0;
+}

--- a/src/dht22.h
+++ b/src/dht22.h
@@ -1,0 +1,9 @@
+#ifndef DHT22_H
+#define DHT22_H
+#include <stdint.h>
+
+// Reads temperature (0.1 C units) and humidity (0.1 % units)
+// Returns 0 on success
+uint8_t dht22_read(int16_t *temp, uint16_t *hum);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -1,0 +1,33 @@
+#include <xc.h>
+#include <stdint.h>
+#include "config.h"
+#include "ow_slave.h"
+
+#define _XTAL_FREQ 8000000UL
+
+#pragma config FOSC = INTOSC
+#pragma config WDTE = OFF
+#pragma config PWRTE = OFF
+#pragma config MCLRE = OFF
+#pragma config CP = OFF
+#pragma config BOREN = ON
+#pragma config CLKOUTEN = OFF
+#pragma config IESO = OFF
+#pragma config FCMEN = OFF
+#pragma config WRT = OFF
+#pragma config PLLEN = OFF
+#pragma config STVREN = OFF
+#pragma config BORV = HI
+#pragma config LVP = OFF
+
+void main(void) {
+    OSCCON = 0x70; // 8MHz internal
+    ANSELA = 0; // all digital
+    TRISA0 = 1; // OW pin input
+    TRISA1 = 1; // DHT22 input
+
+    ow_init();
+    while(1) {
+        ow_process();
+    }
+}

--- a/src/ow_slave.c
+++ b/src/ow_slave.c
@@ -1,0 +1,153 @@
+#include <xc.h>
+#include <stdint.h>
+#include "config.h"
+#include "dht22.h"
+#include "ow_slave.h"
+
+#define _XTAL_FREQ 8000000UL
+
+// global measurement values
+int16_t temperature = 0; // 0.1C
+uint16_t humidity = 0;   // 0.1%
+
+static const uint8_t rom[8] = {
+    OW_ROM_FAMILY,
+    OW_ROM_SERIAL1,
+    OW_ROM_SERIAL2,
+    OW_ROM_SERIAL3,
+    OW_ROM_SERIAL4,
+    OW_ROM_SERIAL5,
+    OW_ROM_SERIAL6,
+    OW_ROM_CRC
+};
+
+static uint8_t page0[8];
+static uint8_t page0_crc;
+
+static uint8_t crc8(const uint8_t *data, uint8_t len) {
+    uint8_t crc = 0;
+    while(len--) {
+        uint8_t inbyte = *data++;
+        for(uint8_t i=0;i<8;i++) {
+            uint8_t mix = (crc ^ inbyte) & 0x01;
+            crc >>=1;
+            if(mix) crc ^= 0x8C;
+            inbyte >>=1;
+        }
+    }
+    return crc;
+}
+
+static void update_page0(void) {
+    page0[0] = temperature & 0xFF;
+    page0[1] = (temperature >> 8) & 0xFF;
+    page0[2] = humidity & 0xFF;
+    page0[3] = (humidity >> 8) & 0xFF;
+    page0[4] = page0[5] = page0[6] = page0[7] = 0;
+    page0_crc = crc8(page0,8);
+}
+
+static void bus_release(void) { OW_TRIS = 1; }
+static void bus_low(void) { OW_PIN = 0; OW_TRIS = 0; }
+static uint8_t bus_read(void) { return OW_PIN; }
+
+// wait for reset pulse and send presence
+static uint8_t ow_wait_reset(void) {
+    // wait for line low
+    if(bus_read()) return 0; // bus idle high expected
+    while(!bus_read()); // wait for rising edge
+    __delay_us(15); // presence after 15us
+    bus_low();
+    __delay_us(240);
+    bus_release();
+    __delay_us(240);
+    return 1;
+}
+
+static uint8_t read_bit(void) {
+    while(bus_read()); // wait for master start
+    __delay_us(15);
+    uint8_t b = bus_read();
+    while(!bus_read());
+    return b;
+}
+
+static void write_bit(uint8_t b) {
+    while(bus_read()); // wait for master read slot
+    if(b) {
+        __delay_us(6);
+        bus_release();
+        __delay_us(64);
+    } else {
+        bus_low();
+        __delay_us(60);
+        bus_release();
+    }
+    while(!bus_read());
+}
+
+static uint8_t read_byte(void) {
+    uint8_t val=0;
+    for(uint8_t i=0;i<8;i++) {
+        if(read_bit()) val |= (1<<i);
+    }
+    return val;
+}
+
+static void write_byte(uint8_t val) {
+    for(uint8_t i=0;i<8;i++) {
+        write_bit(val & 0x01);
+        val >>=1;
+    }
+}
+
+static void send_page0(void) {
+    for(uint8_t i=0;i<8;i++) write_byte(page0[i]);
+    write_byte(page0_crc);
+}
+
+void ow_init(void) {
+    bus_release();
+    update_page0();
+}
+
+void ow_process(void) {
+    if(!ow_wait_reset()) return;
+    uint8_t cmd = read_byte();
+
+    if(cmd == 0x33) { // READ ROM
+        for(uint8_t i=0;i<8;i++) write_byte(rom[i]);
+        return;
+    } else if(cmd == 0xF0) { // SEARCH ROM (single device)
+        for(uint8_t i=0;i<64;i++) {
+            uint8_t b = (rom[i/8] >> (i%8)) & 1;
+            write_bit(b);
+            write_bit(!b);
+            uint8_t master = read_bit();
+            if(master != b) return; // not selected
+        }
+        return;
+    } else if(cmd == 0x55) { // MATCH ROM
+        for(uint8_t i=0;i<8;i++) {
+            uint8_t b = read_byte();
+            if(b != rom[i]) return;
+        }
+        cmd = read_byte();
+    } else if(cmd == 0xCC) { // SKIP ROM
+        cmd = read_byte();
+    } else {
+        return;
+    }
+
+    switch(cmd) {
+        case 0x44: // Convert T
+            dht22_read(&temperature,&humidity);
+            update_page0();
+            break;
+        case 0xBE: // Read Scratchpad (page0)
+            send_page0();
+            break;
+        default:
+            break;
+    }
+}

--- a/src/ow_slave.h
+++ b/src/ow_slave.h
@@ -1,0 +1,11 @@
+#ifndef OW_SLAVE_H
+#define OW_SLAVE_H
+#include <stdint.h>
+
+void ow_init(void);
+void ow_process(void);
+
+extern int16_t temperature; // in 0.1 C
+extern uint16_t humidity;   // in 0.1 %
+
+#endif


### PR DESCRIPTION
## Summary
- implement firmware for PIC12F1822 that reads DHT22 and emulates a DS2438 1‑Wire device
- include simple DHT22 driver and 1‑Wire slave implementation based on OneWireHub timing
- document how to build, flash and change the 1‑Wire address

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de71beb9c832fa948682b2909541f